### PR TITLE
refactor: remove user stage initialization in check-in logic

### DIFF
--- a/contracts/OkzooV2.sol
+++ b/contracts/OkzooV2.sol
@@ -92,7 +92,6 @@ contract OkzooV2 is IOkzooV2, IOkzooV2Errors, OwnableUpgradeable, EIP712Upgradea
             // if user has never checked in before, set streak to 1 and stage to Protoform
             if (user.lastCheckinDate == 0) {
                 user.streak = 1;
-                user.stage = EvolutionStage.Protoform;
             } else {
                 // if user has checked in before, check if it is consecutive day
                 if (_getDayofTimestamp(user.lastCheckinDate) == currentDate - 1) {


### PR DESCRIPTION
- Removed the initialization of user stage to `EvolutionStage.Protoform` when a user checks in for the first time, simplifying the check-in logic.